### PR TITLE
add objective function to define feature visualization process

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -31,7 +31,7 @@ The following provides an example of how Luna can be used for feature visualizat
         return img
 
     opt_param = featurevis.OptimizationParameters(iterations, learning_rate, optimizer=optimizer)
-    # Visualize channel 30 within the mixed5 layer
+    # Visualize filter 30 within the mixed5 layer. Note that we use filter, while some use channel, to denote a unit within a layer.
     objective = featurevis.objectives.FilterObjective(model, layer="mixed5", filter_index=30)
     activation, image= featurevis.visualize(image, objective=objective, optimization_parameters=opt_param, transformation=my_trans)
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -32,8 +32,8 @@ The following provides an example of how Luna can be used for feature visualizat
 
     opt_param = featurevis.OptimizationParameters(iterations, learning_rate, optimizer=optimizer)
     # Visualize channel 30 within the mixed5 layer
-    objective = featurevis.objectives.FilterObjective(filter_index=30)
-    activation, image= featurevis.visualize(image, model, layer="mixed5", objective=objective, optimization_parameters=opt_param, transformation=my_trans)
+    objective = featurevis.objectives.FilterObjective(model, layer="mixed5", filter_index=30)
+    activation, image= featurevis.visualize(image, objective=objective, optimization_parameters=opt_param, transformation=my_trans)
 
     plt.imshow(image)
     plt.savefig("image.svg")

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -31,7 +31,9 @@ The following provides an example of how Luna can be used for feature visualizat
         return img
 
     opt_param = featurevis.OptimizationParameters(iterations, learning_rate, optimizer=optimizer)
-    activation, image= featurevis.visualize_filter(image, model, layer="mixed5", filter_index=30, optimization_parameters=opt_param, transformation=my_trans)
+    # Visualize channel 30 within the mixed5 layer
+    objective = featurevis.objectives.FilterObjective(filter_index=30)
+    activation, image= featurevis.visualize(image, model, layer="mixed5", objective=objective, optimization_parameters=opt_param, transformation=my_trans)
 
     plt.imshow(image)
     plt.savefig("image.svg")

--- a/luna/featurevis/featurevis.py
+++ b/luna/featurevis/featurevis.py
@@ -13,7 +13,7 @@ from matplotlib.pyplot import figure, imshow, axis
 
 from luna.featurevis import relu_grad as rg
 from luna.featurevis import images as imgs
-from luna.featurevis import objectives as objectives
+from luna.featurevis import objectives
 
 @dataclass
 class OptimizationParameters():
@@ -34,7 +34,7 @@ def visualize(
 
     Args:
         image (array): the image to be modified by the feature vis process.
-        objective (object): computes the activation to optimize visualization for, e.g., filter or layer.
+        objective (object): computes the loss to optimize visualization for (filter or layer).
         optimization_parameters (OptimizationParameters): the optimizer class to be applied.
         filter_index (number): the index of the filter to be visualized. Whole layer if None.
         transformations (function): a function defining the transformations to be perfromed.
@@ -113,7 +113,6 @@ def visualize_filter(
     """
     objective = objectives.FilterObjective(model, layer, filter_index, regularization)
     return visualize(image, objective, optimization_parameters, transformation, threshold, minimize)
-    
 
 def visualize_layer(
     image,
@@ -149,7 +148,7 @@ def gradient_ascent_step(img, objective, optimization_parameters, minimize):
 
       Args:
           img (array): the image to be changed by the gradiend ascend.
-          objective (object): computes the activation to optimize visualization for, e.g., filter or layer.
+          objective (object): computes the loss to optimize visualization for (filter or layer).
           optimization_parameters (OptimizationParameters): optimizer (only Adam is supported)
           minimize (bool): whether or not to apply minimize as opposed to calling apply_gradient()
                            for adam optimizer.

--- a/luna/featurevis/featurevis.py
+++ b/luna/featurevis/featurevis.py
@@ -26,7 +26,6 @@ def visualize(
     image,
     objective,
     optimization_parameters,
-    filter_index=None,
     transformation=None,
     threshold=None,
     minimize=False
@@ -145,8 +144,7 @@ def visualize_layer(
     objective = objectives.LayerObjective(model, layer, regularization)
     return visualize(image, objective, optimization_parameters, transformation, threshold, minimize)
 
-def gradient_ascent_step(img, objective, optimization_parameters,
-                         minimize):
+def gradient_ascent_step(img, objective, optimization_parameters, minimize):
     """Performs one step of gradient ascent.
 
       Args:

--- a/luna/featurevis/featurevis.py
+++ b/luna/featurevis/featurevis.py
@@ -14,6 +14,7 @@ from matplotlib.pyplot import figure, imshow, axis
 from luna.featurevis import relu_grad as rg
 from luna.featurevis import images as imgs
 from luna.featurevis import transformations as trans
+from luna.featurevis import objectives as objectives
 
 @dataclass
 class OptimizationParameters():
@@ -22,6 +23,74 @@ class OptimizationParameters():
     learning_rate: Optional[int]
     optimizer: Optional[object]
 
+def visualize(
+    image,
+    model,
+    layer,
+    objective,
+    optimization_parameters,
+    transformation=None,
+    threshold=None,
+    minimize = False
+):
+    """Create a feature visualization for a filter in a layer of the model.
+
+    Args:
+        image (array): the image to be modified by the feature vis process.
+        model (object): the model to be used for the feature visualization.
+        layer (string): the name of the layer to be used in the visualization.
+        objective (object): computes the activation to optimize visualization for, e.g., filter or layer.
+        optimization_parameters (OptimizationParameters): the optimizer class to be applied.
+        transformations (function): a function defining the transformations to be perfromed.
+        regularization (function): customized regularizers to be applied. Defaults to None.
+        threshold (list): Intermediate steps for visualization. Defaults to None.
+        minimize (bool): whether or not to apply minimize as opposed to calling apply_gradient()
+                         for adam optimizer.
+
+    Returns:
+        tuple: activation and result image for the process.
+    """
+    image = tf.Variable(image)
+    feature_extractor = get_feature_extractor(model, layer)
+    _threshold_figures = figure(figsize=(15, 10), dpi=200)
+
+    print("Starting Feature Vis Process")
+    for iteration in range(optimization_parameters.iterations):
+        pctg = int(iteration / optimization_parameters.iterations * 100)
+
+        if transformation:
+            if not callable(transformation):
+                raise ValueError("The transformations need to be a function.")
+            image = transformation(image)
+        else:
+            image = trans.standard_transformation(image)
+
+        activation, image = gradient_ascent_step(
+            image, feature_extractor, objective,
+            optimization_parameters, minimize=minimize
+        )
+
+        print('>>', pctg, '%', end="\r", flush=True)
+
+        # Routine for creating a threshold image for Jupyter Notebooks
+        if isinstance(threshold, list) and (iteration in threshold):
+            threshold_image = _threshold_figures.add_subplot(
+                1, len(threshold), threshold.index(iteration) + 1
+            )
+            threshold_image.title.set_text(f"Step {iteration}")
+            threshold_view(image)
+
+    print('>> 100 %')
+    if image.shape[1] < 299 or image.shape[2] < 299:
+        image = tf.image.resize(image, [299, 299])
+
+    # Decode the resulting input image when gradient ascent is used.
+    if (minimize is False) and (optimization_parameters.optimizer is None):
+        image = imgs.deprocess_image(image[0].numpy())
+    else:
+        image= image[0].numpy()
+
+    return activation, image
 
 def visualize_filter(
     image,
@@ -51,77 +120,40 @@ def visualize_filter(
     Returns:
         tuple: activation and result image for the process.
     """
-    image = tf.Variable(image)
-    feature_extractor = get_feature_extractor(model, layer)
-    _threshold_figures = figure(figsize=(15, 10), dpi=200)
+    objective = objectives.FilterObjective(filter_index, regularization)
+    return visualize(image, model, layer, objective, optimization_parameters, transformation, threshold, minimize)
+    
 
-    print("Starting Feature Vis Process")
-    for iteration in range(optimization_parameters.iterations):
-        pctg = int(iteration / optimization_parameters.iterations * 100)
-
-        if transformation:
-            if not callable(transformation):
-                raise ValueError("The transformations need to be a function.")
-            image = transformation(image)
-        else:
-            image = trans.standard_transformation(image)
-
-        activation, image = gradient_ascent_step(
-            image, feature_extractor, filter_index, regularization,
-            optimization_parameters, minimize=minimize
-        )
-
-        print('>>', pctg, '%', end="\r", flush=True)
-
-        # Routine for creating a threshold image for Jupyter Notebooks
-        if isinstance(threshold, list) and (iteration in threshold):
-            threshold_image = _threshold_figures.add_subplot(
-                1, len(threshold), threshold.index(iteration) + 1
-            )
-            threshold_image.title.set_text(f"Step {iteration}")
-            threshold_view(image)
-
-    print('>> 100 %')
-    if image.shape[1] < 299 or image.shape[2] < 299:
-        image = tf.image.resize(image, [299, 299])
-
-    # Decode the resulting input image when gradient ascent is used.
-    if (minimize is False) and (optimization_parameters.optimizer is None):
-        image = imgs.deprocess_image(image[0].numpy())
-    else:
-        image= image[0].numpy()
-
-    return activation, image
-
-
-def compute_activation(input_image, model, filter_index, regularization):
-    """Computes the loss for the feature visualization process.
+def visualize_layer(
+    image,
+    model,
+    layer,
+    optimization_parameters,
+    transformation=None,
+    regularization=None,
+    threshold=None,
+    minimize = False
+):
+    """Create deep dream visualization of a layer in the model.
 
     Args:
-        input_image (array): the image that is used to compute the loss.
-        model (object): the model on which to compute the loss.
-        filter_index (int): for which filter to compute the loss.
-        Defaults to False.
-        regularization (function): a function defining the regularizations to be perfromed.
+        image (array): the image to be modified by the feature vis process.
+        model (object): the model to be used for the feature visualization.
+        layer (string): the name of the layer to be used in the visualization.
+        optimization_parameters (OptimizationParameters): the optimizer class to be applied.
+        transformations (function): a function defining the transformations to be perfromed.
+        regularization (function): customized regularizers to be applied. Defaults to None.
+        threshold (list): Intermediate steps for visualization. Defaults to None.
+        minimize (bool): whether or not to apply minimize as opposed to calling apply_gradient()
+                         for adam optimizer.
 
     Returns:
-        number: the activation for the specified setting
+        tuple: activation and result image for the process.
     """
+    objective = objectives.LayerObjective(regularization)
+    return visualize(image, model, layer, objective, optimization_parameters, transformation, threshold, minimize)
 
-    activation = model(input_image)
-    if tf.compat.v1.keras.backend.image_data_format() == "channels_first":
-        filter_activation = activation[:, filter_index, :, :]
-    else:
-        filter_activation = activation[:, :, :, filter_index]
-    activation_score = tf.reduce_mean(filter_activation)
-    if regularization:
-        if not callable(regularization):
-            raise ValueError("The regularizations need to be a function.")
-        activation_score = regularization(activation, activation_score)
-    return activation_score
-
-
-def gradient_ascent_step(img, model, filter_index, regularization, optimization_parameters,
+def gradient_ascent_step(img, model, objective, optimization_parameters,
                          minimize):
     """Performing one step of gradient ascend.
 
@@ -141,8 +173,7 @@ def gradient_ascent_step(img, model, filter_index, regularization, optimization_
     if not minimize:
         with tf.GradientTape() as tape:
             tape.watch(img)
-            activation = compute_activation(
-                img, model, filter_index, regularization)
+            activation = -objective.loss(img, model)
 
         # Compute gradients.
         grads = tape.gradient(activation, img)
@@ -159,9 +190,7 @@ def gradient_ascent_step(img, model, filter_index, regularization, optimization_
             optimization_parameters.optimizer.apply_gradients(zip([grads_modified], [img]))
     else:
         def compute_loss():
-            activation = compute_activation(img, model, filter_index, regularization)
-            activation = (-1)*activation
-            return activation
+            return objective.loss(img, model)
         activation = optimization_parameters.optimizer.minimize(compute_loss, [img])
     return activation, img
 

--- a/luna/featurevis/images.py
+++ b/luna/featurevis/images.py
@@ -16,7 +16,7 @@ MAX_NORM_SVD_SQRT = np.max(np.linalg.norm(COLOR_CORRELATION_SVD_SQRT, axis=0))
 COLOR_MEAN = [0.48, 0.46, 0.41]
 
 
-def initialize_image(width, height, val_range_top=1.0, val_range_bottom=-1.0):
+def initialize_image(width, height, channels = 3, val_range_top=1.0, val_range_bottom=-1.0):
     """
     Creates an initial randomized image to start feature vis process.
     This could be subject to optimization in the future.
@@ -29,11 +29,13 @@ def initialize_image(width, height, val_range_top=1.0, val_range_bottom=-1.0):
         A randomly generated image.
     """
     print("initializing image")
+    if channels != 1 and channels != 3:
+        raise ValueError("Only 1 and 3 image channels are currently supported.")
     # We start from a gray image with some random noise
     if tf.compat.v1.keras.backend.image_data_format() == "channels_first":
-        img = tf.random.uniform((1, 3, width, height), dtype=tf.dtypes.float32)
+        img = tf.random.uniform((1, channels, width, height), dtype=tf.dtypes.float32)
     else:
-        img = tf.random.uniform((1, width, height, 3), dtype=tf.dtypes.float32)
+        img = tf.random.uniform((1, width, height, channels), dtype=tf.dtypes.float32)
     # rescale values to be in the middle quarter of possible values
     img = (img - 0.5) * 0.25 + 0.5
     val_range = val_range_top - val_range_bottom
@@ -88,7 +90,7 @@ def save_image(img, name=None):
 
 
 def initialize_image_ref(
-    width, height, std=None, fft=True, decorrelate=True, channels=None,  seed=None
+    width, height, channels=3, std=None, fft=True, decorrelate=True,  seed=None
 ):
     """
     Creates an initial randomized image to start feature vis process.
@@ -97,10 +99,10 @@ def initialize_image_ref(
     Args:
         width (int): The width of the image.
         height (int): The height of the image.
+        channels (int): Number of image channels.
         sd (float): standard deviation for noise initialization.
         fft (boolean): Image parameterization with fast fourier transformation.
         deccorelate (boolean): the color interpretation of the image tensor's color.
-        channels (boolean): True for gray images.
         seed (int): Random seed for the image initialization for reproducibility.
 
     Returns:
@@ -109,9 +111,9 @@ def initialize_image_ref(
     print("initializing image")
     # We start from a gray image with some random noise
     if tf.compat.v1.keras.backend.image_data_format() == "channels_first":
-        img = tf.random.uniform((1, 3, width, height), dtype=tf.dtypes.float32)
+        img = tf.random.uniform((1, channels, width, height), dtype=tf.dtypes.float32)
     else:
-        img = tf.random.uniform((1, width, height, 3), dtype=tf.dtypes.float32)
+        img = tf.random.uniform((1, width, height, channels), dtype=tf.dtypes.float32)
 
     if fft:
         image_f = fft_image(img, std=std)
@@ -124,11 +126,13 @@ def initialize_image_ref(
                   img.shape[2], img.shape[3]], scale=std
         ).astype(np.float32)
 
-    if channels:
-        output = tf.nn.sigmoid(image_f)
-    else:
+    if channels == 3:
         output = to_valid_rgb(
             image_f[..., :3], decorrelate=decorrelate, sigmoid=True)
+    else:
+        output = tf.nn.sigmoid(image_f)
+
+        
 
     return output
 

--- a/luna/featurevis/images.py
+++ b/luna/featurevis/images.py
@@ -224,6 +224,6 @@ def to_valid_rgb(image, decorrelate=False, sigmoid=True):
     if sigmoid:
         image = tf.nn.sigmoid(image)
     else:
-        image = (2 * image - 1 / tf.maximum(1.0,
-                 tf.abs(2 * image - 1))) / 2 + 0.5
+        val = (2 * image - 1)
+        image = (val / tf.maximum(1.0, tf.abs(val))) / 2 + 0.5
     return image

--- a/luna/featurevis/images.py
+++ b/luna/featurevis/images.py
@@ -109,10 +109,7 @@ def initialize_image_ref(
         A randomly generated image.
     """
     print("initializing image")
-    if tf.compat.v1.keras.backend.image_data_format() == "channels_first":
-        shape = (1, channels, width, height)
-    else:
-        shape = (1, width, height, channels)
+    shape = _to_img_shape(width, height, channels)
 
     if fft:
         image_f = fft_image(width, height, channels, std=std)
@@ -120,7 +117,6 @@ def initialize_image_ref(
         std = std or 0.01
         if seed is not None:
             np.random.seed(seed)
-        shape = _to_img_shape(width, height, channels)
         image_f = np.random.normal(size=shape, scale=std).astype(np.float32)
 
     if channels == 3:
@@ -200,20 +196,19 @@ def _linear_decorrelate_color(image):
     return image
 
 
-def _to_img_shape(width, height, channels=3, batch=1):
+def _to_img_shape(width, height, channels=3):
     """Returns image dimensions depending on tensorflow channels first backend format.
 
     Args:
         width (int): Image width.
         height (int): Image height.
         channels (int): Number of image channels.
-        batch (int): Batch size.
 
     Returns:
-        (batch, channels, width, height) if channels_first,
-        otherwise (batch, width, height, channels).
+        (1, channels, width, height) if channels_first,
+        otherwise (1, width, height, channels).
     """
-
+    batch = 1
     if tf.compat.v1.keras.backend.image_data_format() == "channels_first":
         return (batch, channels, width, height)
 

--- a/luna/featurevis/images.py
+++ b/luna/featurevis/images.py
@@ -131,9 +131,7 @@ def initialize_image_ref(
             image_f[..., :3], decorrelate=decorrelate, sigmoid=True)
     else:
         output = tf.nn.sigmoid(image_f)
-
-        
-
+    
     return output
 
 

--- a/luna/featurevis/objectives.py
+++ b/luna/featurevis/objectives.py
@@ -1,13 +1,13 @@
 import tensorflow as tf
 
 class FilterObjective(object):
-    """ Feature visualization of a given channel in a layer of a model.
-        Computes the mean activation of the specified channel.
+    """ Feature visualization of a given filter in a layer of a model.
+        Computes the mean activation of the specified filter. 
     """
         
     def __init__(self, model, layer, filter_index, regularization=None):
-        """ Feature visualization of a given channel in a layer of a model.
-            Computes the mean activation of the channel.
+        """ Feature visualization of a given filter in a layer of a model.
+            Computes the mean activation of the filter.
             Args: 
                 model (object): the model to be used for the feature visualization.
                 layer (string): the name of the layer to be used in the visualization.

--- a/luna/featurevis/objectives.py
+++ b/luna/featurevis/objectives.py
@@ -1,0 +1,71 @@
+import tensorflow as tf
+
+class FilterObjective(object):
+    """ Feature visualization of a given channel in a layer of a model.
+        Computes the mean activation of the specified channel.
+    """
+        
+    def __init__(self, filter_index, regularization=None):
+        """ Feature visualization of a given channel in a layer of a model.
+            Computes the mean activation of the channel.
+            Args: 
+                filter_index (number): the index of the filter to be visualized.
+                regularization (function): customized regularizers to be applied. Defaults to None.
+        """
+        self.filter_index = filter_index
+        self.regularization = regularization
+
+    def loss(self, input_image, model):
+        """Computes the loss for the feature visualization process.
+
+        Args:
+            input_image (array): the image that is used to compute the loss.
+            model (object): the model on which to compute the loss.
+        Returns:
+            number: the loss for the specified setting
+        """
+
+        activation = model(input_image)
+        if tf.compat.v1.keras.backend.image_data_format() == "channels_first":
+            filter_activation = activation[:, self.filter_index, :, :]
+        else:
+            filter_activation = activation[:, :, :, self.filter_index]
+        activation_score = tf.reduce_mean(filter_activation)
+        if self.regularization:
+            if not callable(self.regularization):
+                raise ValueError("The regularizations need to be a function.")
+            activation_score = self.regularization(activation, activation_score)
+        return -activation_score
+
+class LayerObjective(object):
+    """ Deepdream visualization of a layer, see Mordvintsev et al. 2015.
+        Computes (mean activation)^2 of the input.
+    """
+    def __init__(self, regularization=None):
+        """ Deepdream visualization of a layer, see Mordvintsev et al. 2015.
+            Computes (mean activation)^2 of the input.
+            Args: 
+                regularization (function): customized regularizers to be applied. Defaults to None.
+        """
+        self.regularization = regularization
+
+    def loss(self, input_image, model):
+        """Computes the layer loss for the feature visualization process.
+
+        Args:
+            input_image (array): the image that is used to compute the loss.
+            model (object): the model on which to compute the loss.
+        Returns:
+            number: the activation for the specified setting
+        """
+
+        activation = model(input_image)
+        activation_score = tf.reduce_mean(activation**2)
+        if self.regularization:
+            if not callable(self.regularization):
+                raise ValueError("The regularizations need to be a function.")
+            activation_score = self.regularization(activation, activation_score)
+        return -activation_score
+
+
+

--- a/luna/featurevis/objectives.py
+++ b/luna/featurevis/objectives.py
@@ -1,14 +1,18 @@
+"""
+Methods for computing the loss for which to optimize the visualization for.
+"""
 import tensorflow as tf
 
-class FilterObjective(object):
+
+class FilterObjective:
     """ Feature visualization of a given filter in a layer of a model.
-        Computes the mean activation of the specified filter. 
+        Computes the mean activation of the specified filter.
     """
-        
+
     def __init__(self, model, layer, filter_index, regularization=None):
         """ Feature visualization of a given filter in a layer of a model.
             Computes the mean activation of the filter.
-            Args: 
+            Args:
                 model (object): the model to be used for the feature visualization.
                 layer (string): the name of the layer to be used in the visualization.
                 filter_index (number): the index of the filter to be visualized.
@@ -37,17 +41,23 @@ class FilterObjective(object):
         if self.regularization:
             if not callable(self.regularization):
                 raise ValueError("The regularizations need to be a function.")
-            activation_score = self.regularization(activation, activation_score)
+            activation_score = self.regularization(
+                activation, activation_score)
         return -activation_score
 
-class LayerObjective(object):
+    def __repr__(self) -> str:
+        return f"FilterObjective({self.model}, {self.filter_index}, {self.regularization})"
+
+
+class LayerObjective:
     """ Deepdream visualization of a layer, see Mordvintsev et al. 2015.
         Computes (mean activation)^2 of the input.
     """
+
     def __init__(self, model, layer, regularization=None):
         """ Deepdream visualization of a layer, see Mordvintsev et al. 2015.
             Computes (mean activation)^2 of the input.
-            Args: 
+            Args:
                 model (object): the model to be used for the feature visualization.
                 layer (string): the name of the layer to be used in the visualization.
                 regularization (function): customized regularizers to be applied. Defaults to None.
@@ -70,8 +80,13 @@ class LayerObjective(object):
         if self.regularization:
             if not callable(self.regularization):
                 raise ValueError("The regularizations need to be a function.")
-            activation_score = self.regularization(activation, activation_score)
+            activation_score = self.regularization(
+                activation, activation_score)
         return -activation_score
+
+    def __repr__(self) -> str:
+        return f"LayerObjective({self.model}, {self.regularization})"
+
 
 def get_feature_extractor(model, layer_name):
     """Builds a model that that returns the activation of the specified layer.
@@ -82,5 +97,3 @@ def get_feature_extractor(model, layer_name):
     """
     layer = model.get_layer(name=layer_name)
     return tf.keras.Model(inputs=model.inputs, outputs=layer.output)
-
-

--- a/luna/featurevis/objectives.py
+++ b/luna/featurevis/objectives.py
@@ -24,14 +24,12 @@ class FilterObjective:
 
     def loss(self, input_image):
         """Computes the loss for the feature visualization process.
-
         Args:
             input_image (array): the image that is used to compute the loss.
             model (object): the model on which to compute the loss.
         Returns:
             number: the loss for the specified setting
         """
-
         activation = self.model(input_image)
         if tf.compat.v1.keras.backend.image_data_format() == "channels_first":
             filter_activation = activation[:, self.filter_index, :, :]
@@ -67,14 +65,12 @@ class LayerObjective:
 
     def loss(self, input_image):
         """Computes the layer loss for the feature visualization process.
-
         Args:
             input_image (array): the image that is used to compute the loss.
             model (object): the model on which to compute the loss.
         Returns:
             number: the loss for the specified setting
         """
-
         activation = self.model(input_image)
         activation_score = tf.reduce_mean(activation**2)
         if self.regularization:
@@ -107,14 +103,12 @@ class LayerActivationObjective:
 
     def loss(self, input_image):
         """Computes the layer loss for the feature visualization process.
-
         Args:
             input_image (array): the image that is used to compute the loss.
             model (object): the model on which to compute the loss.
         Returns:
             number: the loss for the specified setting
         """
-
         activation = self.model(input_image)
         activation_score = -tf.reduce_mean((self.target_activation - activation)**2)
         if self.regularization:


### PR DESCRIPTION
**Describe your improvements**
- Added layer-level deep dream visualization and refactored to promote code reusability. Different objectives can now be used to do filter/layer level visualization. 
- Separated image transformation so that it is only performed for loss computation, not for optimization. The standard transformations did not work as expected otherwise.

Using standard_transformation, before/after this PR (`images.initialize_image_ref(299, 299, fft=False, decorrelate=False, seed=1)`)
![inceptionv3_optimize_transformed](https://user-images.githubusercontent.com/8738140/177168369-22be365c-8430-427d-9785-b754ebb1c033.png)
![inceptionv3_optimize_param](https://user-images.githubusercontent.com/8738140/177168412-08e7053a-4a36-4fb3-9c6a-4a28d7832f6f.png)

